### PR TITLE
Fix messages starting with a prefix being pushed to conversationLog

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ client.on('messageCreate', async (message) => {
     prevMessages.reverse();
     
     prevMessages.forEach((msg) => {
-      if (message.content.startsWith('!')) return;
+      if (msg.content.startsWith('!')) return;
       if (msg.author.id !== client.user.id && message.author.bot) return;
       if (msg.author.id == client.user.id) {
         conversationLog.push({


### PR DESCRIPTION
It works even with this fault because message starts with ! Doesn't even trigger the message but it will be send to the api request or something like that if it was a previous message. ( I hope if this makes a sense ).